### PR TITLE
for-purchase variations

### DIFF
--- a/analysis/strategy-perf-overall.js
+++ b/analysis/strategy-perf-overall.js
@@ -149,8 +149,8 @@ module.exports = async (Robinhood, includeToday, daysBack = NUM_DAYS, minCount =
         })
         .slice(0);
 
-    console.log('sorted by perc up')
-    console.table(sortedByPercUp);
+    // console.log('sorted by perc up')
+    // console.table(sortedByPercUp);
 
     const sortedByHundredResult = withData
         // .filter(t => t.trend.length > 30)

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -128,7 +128,7 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
 
         for (let pos of underNDays) {
             // const strategy = await findStrategyThatPurchasedTicker(pos.symbol);
-            const breakdowns = await getStratPerfTrends(pos.ticker, pos.date, pos.strategy) || [];
+            const breakdowns = await getStratPerfTrends(pos.ticker, pos.date, pos.buyStrategy) || [];
             if (!breakdowns.length) {
                 breakdowns.push(
                     getTrend(

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -111,7 +111,7 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
         console.log({ underNDays });
         if (!underNDays.length) return;
         
-        const strategiesToLookup = underNDays.map(pos => pos.strategy).filter(v => !!v);
+        const strategiesToLookup = underNDays.map(pos => pos.buyStrategy).filter(v => !!v);
         const highestPlayouts = strategiesToLookup.length ?
             await determineSingleBestPlayoutFromMultiOutput(
                 Robinhood,
@@ -119,7 +119,7 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
             ) : [];
         console.log({ strategiesToLookup, highestPlayouts })
         underNDays = underNDays.map(pos => {
-            const foundMatch = highestPlayouts.find(obj => obj.strategy === pos.strategy);
+            const foundMatch = highestPlayouts.find(obj => obj.strategy === pos.buyStrategy);
             return {
                 ...pos,
                 ...(foundMatch && { highestPlayout: foundMatch.highestPlayout })

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -108,7 +108,7 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
 
     const handleUnderNDays = async () => {
         // handle under four days (but not bought today) check for playout strategy
-        let underNDays = nonzero.filter(pos => pos.dayAge >= 1 && pos.dayAge < sellAllStocksOnNthDay);
+        let underNDays = nonzero.filter(pos => pos.dayAge >= 0 && pos.dayAge < sellAllStocksOnNthDay);
         console.log({ underNDays });
         if (!underNDays.length) return;
         

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -108,7 +108,7 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
 
     const handleUnderNDays = async () => {
         // handle under four days (but not bought today) check for playout strategy
-        let underNDays = nonzero.filter(pos => pos.dayAge >= 0 && pos.dayAge < sellAllStocksOnNthDay);
+        let underNDays = nonzero.filter(pos => pos.dayAge >= 1 && pos.dayAge < sellAllStocksOnNthDay);
         console.log({ underNDays });
         if (!underNDays.length) return;
         
@@ -156,8 +156,8 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
                 `playoutToRun: ${pos.playoutToRun}`,
                 `buyStrategy: ${pos.buyStrategy}`,
                 `buyDate: ${pos.buyDate}`,
-                `returnDollars: ${pos.returnDollars}`
-            ].join('\n'))
+                `returnDollars: $${pos.returnDollars}`
+            ].join('\n'));
         });
     };
 

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -154,6 +154,9 @@ module.exports = async (Robinhood, dontActuallySellFlag) => {
             await sendEmail(`robinhood-playground: sold ${pos.symbol}`, [
                 `breakdowns: ${pos.breakdowns}`,
                 `playoutToRun: ${pos.playoutToRun}`,
+                `buyStrategy: ${pos.buyStrategy}`,
+                `buyDate: ${pos.buyDate}`,
+                `returnDollars: ${pos.returnDollars}`
             ].join('\n'))
         });
     };

--- a/app-actions/sell-all-based-on-playout.js
+++ b/app-actions/sell-all-based-on-playout.js
@@ -14,6 +14,7 @@ const StratPerf = require('../models/StratPerf');
 const jsonMgr = require('../utils/json-mgr');
 const getFilesSortedByDate = require('../utils/get-files-sorted-by-date');
 const getTrend = require('../utils/get-trend');
+const sendEmail = require('../utils/send-email');
 
 // app-actions
 const detailedNonZero = require('./detailed-non-zero');

--- a/run.js
+++ b/run.js
@@ -15,6 +15,7 @@ mongoose.connect(mongoConnectionString, { useNewUrlParser: true });
     console.log('asd')
     console.log(process.argv, 'ps');
     let Robinhood = await login();
+    global.Robinhood = Robinhood;
     const argPath = process.argv[2];
     let relatedFile = require(`./${argPath}`);
 

--- a/settings.js
+++ b/settings.js
@@ -30,7 +30,7 @@ module.exports = {
         '[unprovenSuddenDropsLast2Filter10]',
         '[unprovenSuddenDropsLast2Filter10]',
     ],
-    forPurchaseVariation: '50Perc5Day-yesincludingblanks',
+    forPurchaseVariation: '75Perc5Day-yesincludingblanks',
     fallbackSellStrategy: 'limit3',
     force: {
         sell: [

--- a/settings.js
+++ b/settings.js
@@ -30,6 +30,7 @@ module.exports = {
         '[unprovenSuddenDropsLast2Filter10]',
         '[unprovenSuddenDropsLast2Filter10]',
     ],
+    forPurchaseVariation: '50Perc5Day-yesincludingblanks',
     fallbackSellStrategy: 'limit3',
     force: {
         sell: [

--- a/socket-server/create-prediction-models.js
+++ b/socket-server/create-prediction-models.js
@@ -2,9 +2,29 @@ const manualPMs = require('../pms/manual');
 const fiftytwodaySPMs = require('../pms/spm');
 const getMyRecs = require('../pms/my-recs');
 const getTipTop = require('../pms/tip-top');
+const settings = require('../settings');
+const flatten = require('../utils/flatten-array');
+const stratPerfOverall = require('../analysis/strategy-perf-overall');
 
 module.exports = async (Robinhood) => {
-    console.log('TESTING');
+
+    pastData = await (async () => {
+        const stratPerfData = await stratPerfOverall(Robinhood, true, 4);
+        const stratPerfObj = {};
+        stratPerfData.sortedByAvgTrend.forEach(({
+            name,
+            avgTrend,
+            count,
+            percUp
+        }) => {
+            stratPerfObj[name] = {
+                avgTrend,
+                percUp,
+                count
+            };
+        });
+        return { fiveDay: stratPerfObj };
+    })();
 
     const myRecs = await getMyRecs(Robinhood);
     const fiftytwo = await fiftytwodaySPMs(Robinhood);
@@ -24,18 +44,23 @@ module.exports = async (Robinhood) => {
             [`spm-52day-${val}`]: fiftytwo[val]
         }), {}),
 
-        ...await getTipTop(this.Robinhood)
+        ...await getTipTop(Robinhood)
     };
 
     console.log('done donezy');
 
     const flattenStrategiesWithPMs = array =>
         flatten(
-            array.map(strat =>
-                strat && strat.startsWith('[')
-                    ? strategies[strat.substring(1, strat.length - 1)]
-                    : strat
-            )
+            array.map(strat => {
+                if (strat && strat.startsWith('[')) {
+                    const pmStrats = strategies[strat.substring(1, strat.length - 1)];
+                    if (!pmStrats) {
+                        console.log('could not find strat', strat);
+                    }
+                    return pmStrats;
+                }
+                return strat;
+            })
         );
 
     const forPurchase = flattenStrategiesWithPMs(settings.forPurchase);
@@ -43,7 +68,7 @@ module.exports = async (Robinhood) => {
     const forPurchaseVariations = (() => {
         const filterBy5DayPercUp = (perc, includeBlanks) => forPurchase
             .filter(strat => {
-                const foundFiveDay = this.pastData.fiveDay[strat];
+                const foundFiveDay = pastData.fiveDay[strat];
                 return (includeBlanks && !foundFiveDay)
                     || (foundFiveDay && foundFiveDay.percUp >= perc / 100);
             });

--- a/socket-server/create-prediction-models.js
+++ b/socket-server/create-prediction-models.js
@@ -1,0 +1,82 @@
+const manualPMs = require('../pms/manual');
+const fiftytwodaySPMs = require('../pms/spm');
+const getMyRecs = require('../pms/my-recs');
+const getTipTop = require('../pms/tip-top');
+
+module.exports = async (Robinhood) => {
+    console.log('TESTING');
+
+    const myRecs = await getMyRecs(Robinhood);
+    const fiftytwo = await fiftytwodaySPMs(Robinhood);
+    let strategies = {
+
+        ...manualPMs,
+
+        // myRecs
+        ...Object.keys(myRecs).reduce((acc, val) => ({
+            ...acc,
+            [`myRecs-${val}`]: myRecs[val]
+        }), {}),
+        
+        //fiftytwodaySPMs
+        ...Object.keys(fiftytwo).reduce((acc, val) => ({
+            ...acc,
+            [`spm-52day-${val}`]: fiftytwo[val]
+        }), {}),
+
+        ...await getTipTop(this.Robinhood)
+    };
+
+    console.log('done donezy');
+
+    const flattenStrategiesWithPMs = array =>
+        flatten(
+            array.map(strat =>
+                strat && strat.startsWith('[')
+                    ? strategies[strat.substring(1, strat.length - 1)]
+                    : strat
+            )
+        );
+
+    const forPurchase = flattenStrategiesWithPMs(settings.forPurchase);
+
+    const forPurchaseVariations = (() => {
+        const filterBy5DayPercUp = (perc, includeBlanks) => forPurchase
+            .filter(strat => {
+                const foundFiveDay = this.pastData.fiveDay[strat];
+                return (includeBlanks && !foundFiveDay)
+                    || (foundFiveDay && foundFiveDay.percUp >= perc / 100);
+            });
+        return [
+            50,
+            75,
+            80,
+            100
+        ].reduce((acc, perc) => ({
+            [`forPurchase${perc}Perc5Day-notincludingblanks`]: filterBy5DayPercUp(perc),
+            [`forPurchase${perc}Perc5Day-yesincludingblanks`]: filterBy5DayPercUp(perc, true),
+            ...acc
+        }), {});
+    })();
+
+    let forPurchasePMs = {
+        forPurchase,
+        ...forPurchaseVariations
+    };
+
+    const { forPurchaseVariation } = settings;
+    if (forPurchaseVariation) {
+        console.log('FOR PURCHASE VARIATION FOUND', forPurchaseVariation);
+        forPurchasePMs = {
+            ...forPurchasePMs,
+            originalForPurchase: forPurchasePMs.forPurchase,
+            forPurchase: forPurchasePMs[`forPurchase${forPurchaseVariation}`]
+        };
+        console.log(`FOR PURCHASE WENT FROM ${forPurchasePMs.originalForPurchase.length} to ${forPurchasePMs.forPurchase.length} strategies`);
+    }
+
+    return {
+        ...strategies,
+        ...forPurchasePMs
+    };
+};

--- a/socket-server/strat-manager.js
+++ b/socket-server/strat-manager.js
@@ -6,8 +6,6 @@ const fs = require('mz/fs');
 // mongo
 const Pick = require('../models/Pick');
 
-const settings = require('../settings');
-
 // predictions and past data
 const stratPerfOverall = require('../analysis/strategy-perf-overall');
 const { predictCurrent, stratPerfPredictions } = require('../app-actions/predict-top-performing');

--- a/tests/test-stocktwits.js
+++ b/tests/test-stocktwits.js
@@ -1,6 +1,6 @@
 const stocktwits = require('../utils/stocktwits');
 (async() => {
     console.log(
-        await stocktwits.postBullish('BPMX', `I am feeling good about this`)
+        await stocktwits.postBullish('AKER', `testing bullish in the group`)
     )
 })();


### PR DESCRIPTION
creates an extra layer of for-purchase strategy filtering...

the for-purchase variations filter out strategies that may have been included in a pm's picks, but may not meet certain requirements in regards to the five day past data that is shown in the portal

this uses the last 4 days + strategy-perf-today to include the latest data on these strategy perfs (hopefully more in line with the 5 day shown in the portal)

closes issue #13 